### PR TITLE
Fix REST request & response scalar content issues.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,14 +66,14 @@ dependencies {
     implementation "androidx.navigation:navigation-ui:$navigationVersion"
 
     //Google sign in library
-    implementation 'com.google.android.gms:play-services-auth:19.0.0'
+    implementation 'com.google.android.gms:play-services-auth:19.2.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // Gson (Google Json) dependency
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.8'
 
     // OkHttp library
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
@@ -86,7 +86,6 @@ dependencies {
     //Retrofit (Rest client) with ReactiveX and Gson integration
     def retrofit_version = '2.9.0'
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-scalars:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
     implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
 
@@ -104,6 +103,6 @@ dependencies {
     implementation "androidx.room:room-rxjava2:$roomVersion"
 
     // Stetho (inspection) library
-    implementation 'com.facebook.stetho:stetho:1.5.1'
+    implementation 'com.facebook.stetho:stetho:1.6.0'
 
 }

--- a/app/src/main/java/edu/cnm/deepdive/teamassignmentsandroid/service/WebServiceProxy.java
+++ b/app/src/main/java/edu/cnm/deepdive/teamassignmentsandroid/service/WebServiceProxy.java
@@ -8,7 +8,6 @@ import edu.cnm.deepdive.teamassignmentsandroid.model.pojo.Task;
 import edu.cnm.deepdive.teamassignmentsandroid.model.pojo.User;
 import io.reactivex.Completable;
 import io.reactivex.Single;
-import java.util.Date;
 import java.util.List;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -16,12 +15,10 @@ import okhttp3.logging.HttpLoggingInterceptor.Level;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
-import retrofit2.converter.scalars.ScalarsConverterFactory;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
-import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
@@ -42,12 +39,10 @@ public interface WebServiceProxy {
   Single<Group> postGroup(@Body Group group, @Header("Authorization") String bearerToken);
 
   @PUT("groups/{groupId}/members/{userId}")
-  @Headers({"Accept: text/plain", "Content-Type: text/plain"})
   Single<Boolean> putMembership(@Body boolean inGroup, @Path("userId") long userId,
       @Path("groupId") long groupId, @Header("Authorization") String bearerToken);
 
   @GET("groups/{groupId}/members/{userId}")
-  @Headers({"Accept: text/plain"})
   Single<Boolean> getMembership(@Path("groupId") long groupId, @Path("groupId") long userId,
       @Header("Authorization") String bearerToken);
 
@@ -65,7 +60,6 @@ public interface WebServiceProxy {
       @Header("Authorization") String bearerToken);
 
   @PUT("groups/{id}/name")
-  @Headers({"Accept: text/plain", "Content-Type: text/plain"})
   Single<String> renameGroup(@Path("id") long id, @Body String name,
       @Header("Authorization") String bearerToken);
 
@@ -118,7 +112,6 @@ public interface WebServiceProxy {
           .build();
 
       Retrofit retrofit = new Retrofit.Builder()
-          .addConverterFactory(ScalarsConverterFactory.create())
           .addConverterFactory(GsonConverterFactory.create(gson))
           .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
           .client(client)

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
These changes undo the workarounds previously put in place to deal with Spring's bug in handling `String` request & response bodies with the `application/json` content type. A corresponding change on the service side makes these workarounds no longer necessary; removing them also eliminates the need to use `text/plain` content for `String` or `boolean` scalar content.